### PR TITLE
Add Travis script to build+serve book from master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: rust
+rust: stable
+
+cache: cargo
+
+env: MDBOOK=0.1 GHP_UPLOAD=0.3
+
+install:
+- cargo install --version $MDBOOK mdbook
+- cargo install --version $GHP_UPLOAD cargo-ghp-upload
+
+script: mdbook build && cargo ghp-upload --directory book -vv


### PR DESCRIPTION
See <https://github.com/crate-ci/cargo-ghp-upload> for more about the ghp-upload tool.

Build will end up at <https://rust-hosted-langs.github.io/book/master/>.

> This requires Travis to have write-access to your repository. The simplest (and reasonably secure) way to achieve this is to create a [Persional API Access Token](https://github.com/blog/1509-personal-api-tokens) with `public_repoo` scope. Then on Travis, [define the secure environment variable](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings) `GH_TOKEN` with the value being the new token.
> 
> If you want to provide more scoped access, you can use a [deploy key](https://github.com/blog/2024-read-only-deploy-keys) for repo-specific access. If no token is provided, the script will use SSH to clone from and write to the repository. [Travis Pro handles the deploy key automatically](https://blog.travis-ci.com/2012-07-26-travis-pro-update-deploy-keys), and free users can use [Travis encrypt-file](https://docs.travis-ci.com/user/encrypting-files/) plus a script to move the private key into the correct location.
> 
> This also means that `cargo ghp-upload` works locally so long as you have `ssh` set up for your account. Branch and origin context are collected from Git instead of the CI environment. This means that `cargo ghp-upload` will work on CI other than Travis, but you currently have to manually prevent it from running on PR builds if you don't wan't it to.