### PR TITLE
Don't run gh-pages on pull-requests 

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -1,6 +1,6 @@
 name: github pages
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   deploy:


### PR DESCRIPTION
There's nowhere to publish gh-pages to so the step will fail every time.