### PR TITLE
Disambiguate nil and integer 0 in tagged pointers

### DIFF
--- a/interpreter/src/pointerops.rs
+++ b/interpreter/src/pointerops.rs
@@ -15,10 +15,10 @@ pub trait AsNonNull {
 // Pointer tag values and masks using the lowest 2 bits
 // ANCHOR: TaggedPtrTags
 const TAG_MASK: usize = 0x3;
-pub const TAG_NUMBER: usize = 0x0;
-pub const TAG_SYMBOL: usize = 0x1;
-pub const TAG_PAIR: usize = 0x2;
-pub const TAG_OBJECT: usize = 0x3;
+pub const TAG_SYMBOL: usize = 0x0;
+pub const TAG_PAIR: usize = 0x1;
+pub const TAG_OBJECT: usize = 0x2;
+pub const TAG_NUMBER: usize = 0x3;
 const PTR_MASK: usize = !0x3;
 // ANCHOR_END: TaggedPtrTags
 


### PR DESCRIPTION
Fixes #51 the easiest way by shuffling the tag ids such that nil (pointer value 0) and numeric 0 (with tag 0x0) are distinct values.