### PR TITLE
Update Immix paper link

### DIFF
--- a/booksrc/introduction.md
+++ b/booksrc/introduction.md
@@ -42,7 +42,7 @@ All the links below are acknowledged as inspiration or prior art.
 
 * Richard Jones, Anthony Hosking, Elliot Moss - [The Garbage Collection Handbook](http://gchandbook.org/)
 * Stephen M. Blackburn & Kathryn S. McKinley -
-  [Immix: A Mark-Region Garbage Collector with Space Efficiency, Fast Collection, and Mutator Performance](http://www.cs.utexas.edu/users/speedway/DaCapo/papers/immix-pldi-2008.pdf)
+  [Immix: A Mark-Region Garbage Collector with Space Efficiency, Fast Collection, and Mutator Performance](http://users.cecs.anu.edu.au/~steveb/pubs/papers/immix-pldi-2008.pdf)
 * Felix S Klock II - [GC and Rust Part 0: Garbage Collection Background](http://blog.pnkfx.org/blog/2015/10/27/gc-and-rust-part-0-how-does-gc-work/)
 * Felix S Klock II - [GC and Rust Part 1: Specifying the Problem](http://blog.pnkfx.org/blog/2015/11/10/gc-and-rust-part-1-specing-the-problem/)
 * Felix S Klock II - [GC and Rust Part 2: The Roots of the Problem](http://blog.pnkfx.org/blog/2016/01/01/gc-and-rust-part-2-roots-of-the-problem/)

--- a/booksrc/part-stickyimmix.md
+++ b/booksrc/part-stickyimmix.md
@@ -74,4 +74,4 @@ _What this is not: custom memory management to replace the global Rust
 allocator! The APIs we arrive at will be substantially incompatible with the
 global Rust allocator._
 
-[1]: http://www.cs.utexas.edu/users/speedway/DaCapo/papers/immix-pldi-2008.pdf
+[1]: http://users.cecs.anu.edu.au/~steveb/pubs/papers/immix-pldi-2008.pdf


### PR DESCRIPTION
It appears they moved the location of the paper. The [old link](https://www.cs.utexas.edu/users/speedway/DaCapo/papers/immix-pldi-2008.pdf) 404's.
I found the paper [here](http://users.cecs.anu.edu.au/~steveb/pubs/papers/immix-pldi-2008.pdf), there's also an [archive](https://archive.md/CYqh3) someone else made a year ago.