### PR TITLE
Fix wrong return type in simple-bump-allocation inner_alloc example

### DIFF
--- a/booksrc/chapter-simple-bump.md
+++ b/booksrc/chapter-simple-bump.md
@@ -59,7 +59,7 @@ impl BumpBlock {
             None
         } else {
             self.cursor = next_ptr as *const u8;
-            Some(next_ptr)
+            Some(next_ptr as *const u8)
         }
     }
 }


### PR DESCRIPTION
The return type of next_ptr in simple bump allocation inner_alloc example should be *const u8.


